### PR TITLE
reset binded prop when target changed

### DIFF
--- a/src/VueContextMenu.vue
+++ b/src/VueContextMenu.vue
@@ -36,6 +36,7 @@ export default {
       }
     },
     target (target) {
+      this.binded = false
       this.bindEvents()
     }
   },


### PR DESCRIPTION
如果事件已经绑定的情况下target发生变化   因为binded始终为true   则bindEvents里的if判断永远无法成立而直接return 